### PR TITLE
Wrap expressions to clarify linted code

### DIFF
--- a/example/src/main/scala/Example.scala
+++ b/example/src/main/scala/Example.scala
@@ -5,7 +5,8 @@ import com.earldouglas.linearscala.Linear
 case class Box(value: Int) extends Linear
 
 trait UnusedField {
-  val box: Box = Box(42) // error: box is never used
+  val box: Box = // error: box is never used
+    Box(42)
 }
 
 trait FieldUsedOnce {
@@ -25,7 +26,8 @@ trait UnusedParameter {
 }
 
 trait UnusedMethod {
-  def foo(): Box = Box(42) // error: foo is never used
+  def foo(): Box = // error: foo is never used
+    Box(42)
 }
 
 trait UnusedValue {

--- a/input/src/main/scala/fix/LinearTypes.scala
+++ b/input/src/main/scala/fix/LinearTypes.scala
@@ -8,7 +8,8 @@ import com.earldouglas.linearscala.Linear
 case class Box(value: Int) extends Linear
 
 trait UnusedField {
-  val box: Box = Box(42) // assert: LinearTypes
+  val box: Box = // assert: LinearTypes
+    Box(42)
 }
 
 trait FieldUsedOnce {
@@ -28,7 +29,8 @@ trait UnusedParameter {
 }
 
 trait UnusedMethod {
-  def foo(): Box = Box(42) // assert: LinearTypes
+  def foo(): Box = // assert: LinearTypes
+    Box(42)
 }
 
 trait UnusedValue {


### PR DESCRIPTION
This moves non-erroneous code to help show which line of code triggers
the linting rules.