### PR TITLE
Add tests of for comprehension bindings

### DIFF
--- a/input/src/main/scala/fix/Box.scala
+++ b/input/src/main/scala/fix/Box.scala
@@ -1,0 +1,8 @@
+/*
+rule = LinearTypes
+*/
+package fix
+
+import com.earldouglas.linearscala.Linear
+
+case class Box(value: Int) extends Linear

--- a/input/src/main/scala/fix/Overused.scala
+++ b/input/src/main/scala/fix/Overused.scala
@@ -1,0 +1,24 @@
+/*
+rule = LinearTypes
+*/
+package fix
+
+trait FieldUsedTwice {
+  val box: Box = Box(42)
+  println(box) // assert: LinearTypes
+  println(box) // assert: LinearTypes
+}
+
+trait BindingUsedTwice {
+  for {
+    x <- Some(Box(6))
+    y <- Some(Box(x.value + 1)) // assert: LinearTypes
+    z <- Some(Box(x.value * y.value)) // assert: LinearTypes
+  } yield z
+
+  for {
+    x <- Some(Box(6))
+    y <- Some(Box(7))
+    z <- Some(Box(x.value * y.value)) // assert: LinearTypes
+  } yield (x, y, z) // assert: LinearTypes
+}

--- a/input/src/main/scala/fix/SingleUse.scala
+++ b/input/src/main/scala/fix/SingleUse.scala
@@ -1,0 +1,9 @@
+/*
+rule = LinearTypes
+*/
+package fix
+
+trait FieldUsedOnce {
+  val box: Box = Box(42)
+  println(box)
+}

--- a/input/src/main/scala/fix/Unused.scala
+++ b/input/src/main/scala/fix/Unused.scala
@@ -3,24 +3,9 @@ rule = LinearTypes
 */
 package fix
 
-import com.earldouglas.linearscala.Linear
-
-case class Box(value: Int) extends Linear
-
 trait UnusedField {
   val box: Box = // assert: LinearTypes
     Box(42)
-}
-
-trait FieldUsedOnce {
-  val box: Box = Box(42)
-  println(box)
-}
-
-trait FieldUsedTwice {
-  val box: Box = Box(42)
-  println(box) // assert: LinearTypes
-  println(box) // assert: LinearTypes
 }
 
 trait UnusedParameter {
@@ -39,4 +24,12 @@ trait UnusedValue {
     println(x) // assert: LinearTypes
     println(x) // assert: LinearTypes
   }
+}
+
+trait UnusedBinding {
+  for {
+    x <- Some(Box(6)) // assert: LinearTypes
+    y <- Some(Box(7)) // assert: LinearTypes
+    z <- Some(Box(42))
+  } yield z
 }


### PR DESCRIPTION
This also splits up and organizes the tests by zero/single/multiple use.