### PR TITLE
Add an example of a single-use Closeable

### DIFF
--- a/input/src/main/scala/fix/Closeable.scala
+++ b/input/src/main/scala/fix/Closeable.scala
@@ -1,0 +1,27 @@
+/*
+rule = LinearTypes
+*/
+package fix
+
+import com.earldouglas.linearscala.Linear
+import java.io.RandomAccessFile
+
+/**
+ * Don't allow a [[Linear]] file to be dereferenced more than once,
+ * because it might already be closed.
+ */
+trait ReadFromClosedCloseable {
+
+  def readLineAndCloseFile(f: RandomAccessFile): String = {
+    val line = f.readLine()
+    f.close()
+    line
+  }
+
+  val f: RandomAccessFile with Linear =
+    new RandomAccessFile("/etc/passwd", "r")
+      .asInstanceOf[RandomAccessFile with Linear]
+
+  readLineAndCloseFile(f) // assert: LinearTypes
+  f.readLine() // assert: LinearTypes
+}

--- a/input/src/main/scala/fix/Closeable.scala
+++ b/input/src/main/scala/fix/Closeable.scala
@@ -12,7 +12,9 @@ import java.io.RandomAccessFile
  */
 trait ReadFromClosedCloseable {
 
-  def readLineAndCloseFile(f: RandomAccessFile): String = {
+  def readLineAndCloseFile(
+    f: RandomAccessFile
+  ): String = {
     val line = f.readLine()
     f.close()
     line


### PR DESCRIPTION
This adds an example of file handle that can't accidentally be read
after it has been closed.