### PR TITLE
Fork developer docs from user docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+[![Build Status][build-badge]][build-link]
+[![Release Artifacts][release-badge]][release-link]
+
+[build-badge]: https://github.com/earldouglas/linear-scala/workflows/build/badge.svg "Build Status"
+[build-link]: https://github.com/earldouglas/linear-scala/actions "GitHub Actions"
+[release-link]: https://oss.sonatype.org/content/repositories/releases/com/earldouglas/linear-scala/ "Sonatype Releases"
+[release-badge]: https://img.shields.io/nexus/r/https/oss.sonatype.org/com.earldouglas/linear-scala "Sonatype Releases"
+
+# Contributing
+
+## Testing
+
+Using scalafix-testkit:
+
+```
+$ sbt
+> tests/test
+[info] All tests passed.
+```
+
+## Publishing
+
+Two modules are published from this project:
+
+* *linear-scala*: a standard dependency providing the `Linear` type
+* *linear-scala-scalafix*: a Scalafix dependency providing the
+  `LinearTypes` rule
+
+```
+$ sbt
+> set ThisBuild / version := "0.0.1"
+> library/publishSigned
+> +rules/publishSigned
+> sonatypeBundleRelease
+```
+
+## References
+
+### Scalafix
+
+* https://scalacenter.github.io/scalafix/docs/developers/tutorial.html
+* https://www.javadoc.io/doc/ch.epfl.scala/scalafix-core_2.13/latest/scalafix/index.html
+
+### Scalameta
+
+* https://scalameta.org/docs/trees/guide.html
+* https://scalameta.org/docs/semanticdb/guide.html
+* https://www.javadoc.io/doc/org.scalameta/trees_2.13/latest/scala/meta/index.html

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ trait FieldUsedTwice {
 See the tests in [input/src/main/scala/fix/](input/src/main/scala/fix/)
 for more examples.
 
+## References
+
 ### Linear Types
 
 * https://gitlab.haskell.org/ghc/ghc/-/wikis/linear-types

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 [![Build Status][build-badge]][build-link]
 [![Release Artifacts][release-badge]][release-link]
 
+[build-badge]: https://github.com/earldouglas/linear-scala/workflows/build/badge.svg "Build Status"
+[build-link]: https://github.com/earldouglas/linear-scala/actions "GitHub Actions"
+[release-link]: https://oss.sonatype.org/content/repositories/releases/com/earldouglas/linear-scala/ "Sonatype Releases"
+[release-badge]: https://img.shields.io/nexus/r/https/oss.sonatype.org/com.earldouglas/linear-scala "Sonatype Releases"
+
 # linear-scala
 
 linear-scala adds support for linear types in Scala via a custom
@@ -80,52 +85,8 @@ trait FieldUsedTwice {
 See the tests in [input/src/main/scala/fix/](input/src/main/scala/fix/)
 for more examples.
 
-## Testing
-
-Using scalafix-testkit:
-
-```
-$ sbt
-> tests/test
-[info] All tests passed.
-```
-
-## Publishing
-
-Two modules are published from this project:
-
-* *linear-scala*: a standard dependency providing the `Linear` type
-* *linear-scala-scalafix*: a Scalafix dependency providing the
-  `LinearTypes` rule
-
-```
-$ sbt
-> set ThisBuild / version := "0.0.1"
-> library/publishSigned
-> +rules/publishSigned
-> sonatypeBundleRelease
-```
-
-## References
-
-### Scalafix
-
-* https://scalacenter.github.io/scalafix/docs/developers/tutorial.html
-* https://www.javadoc.io/doc/ch.epfl.scala/scalafix-core_2.13/latest/scalafix/index.html
-
-### Scalameta
-
-* https://scalameta.org/docs/trees/guide.html
-* https://scalameta.org/docs/semanticdb/guide.html
-* https://www.javadoc.io/doc/org.scalameta/trees_2.13/latest/scala/meta/index.html
-
 ### Linear Types
 
 * https://gitlab.haskell.org/ghc/ghc/-/wikis/linear-types
 * https://en.wikipedia.org/wiki/Substructural_type_system#Linear_type_systems
 * https://github.com/ryanorendorff/lc-2018-linear-types
-
-[build-badge]: https://github.com/earldouglas/linear-scala/workflows/build/badge.svg "Build Status"
-[build-link]: https://github.com/earldouglas/linear-scala/actions "GitHub Actions"
-[release-link]: https://oss.sonatype.org/content/repositories/releases/com/earldouglas/linear-scala/ "Sonatype Releases"
-[release-badge]: https://img.shields.io/nexus/r/https/oss.sonatype.org/com.earldouglas/linear-scala "Sonatype Releases"


### PR DESCRIPTION
This separates user documentation and developer documentation into
README.md and CONTRIBUTING.md for clarity and discoverability.