### PR TITLE
Configure source code formatting via Scalafmt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,11 @@
 name: build
-
 on: [push, pull_request]
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - run: sbt tests/test
+    - run: sbt scalafmtCheckAll tests/test

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,1 @@
+maxColumn = 72 // RFC 678: https://datatracker.ietf.org/doc/html/rfc678

--- a/input/src/main/scala/fix/Box.scala
+++ b/input/src/main/scala/fix/Box.scala
@@ -1,12 +1,12 @@
 /*
 rule = LinearTypes
-*/
+ */
 package fix
 
 import com.earldouglas.linearscala.Linear
 
 /**
- * Mix in the [[Linear]] interface to mark instances for use exactly
- * once.
- */
+  * Mix in the [[Linear]] interface to mark instances for use exactly
+  * once.
+  */
 case class Box(value: Int) extends Linear

--- a/input/src/main/scala/fix/Closeable.scala
+++ b/input/src/main/scala/fix/Closeable.scala
@@ -1,19 +1,19 @@
 /*
 rule = LinearTypes
-*/
+ */
 package fix
 
 import com.earldouglas.linearscala.Linear
 import java.io.RandomAccessFile
 
 /**
- * Don't allow a [[Linear]] file to be dereferenced more than once,
- * because it might already be closed.
- */
+  * Don't allow a [[Linear]] file to be dereferenced more than once,
+  * because it might already be closed.
+  */
 trait ReadFromClosedCloseable {
 
   def readLineAndCloseFile(
-    f: RandomAccessFile
+      f: RandomAccessFile
   ): String = {
     val line = f.readLine()
     f.close()

--- a/input/src/main/scala/fix/Overused.scala
+++ b/input/src/main/scala/fix/Overused.scala
@@ -1,13 +1,13 @@
 /*
 rule = LinearTypes
-*/
+ */
 package fix
 
 import com.earldouglas.linearscala.Linear
 
 /**
- * Don't allow a [[Box]] field to be dereferenced more than once.
- */
+  * Don't allow a [[Box]] field to be dereferenced more than once.
+  */
 trait FieldUsedTwice {
   val box: Box = Box(42)
   println(box) // assert: LinearTypes
@@ -15,9 +15,9 @@ trait FieldUsedTwice {
 }
 
 /**
- * Don't allow a [[Box]] binding in a for comprehension to be
- * dereferenced more than once.
- */
+  * Don't allow a [[Box]] binding in a for comprehension to be
+  * dereferenced more than once.
+  */
 trait BindingUsedTwice {
   for {
     x <- Some(Box(6))
@@ -33,9 +33,9 @@ trait BindingUsedTwice {
 }
 
 /**
- * Don't allow a field with a [[Linear]] structural type to be
- * dereferenced more than once.
- */
+  * Don't allow a field with a [[Linear]] structural type to be
+  * dereferenced more than once.
+  */
 trait FieldWithStructuralTypeUsedTwice {
   val x: Int with Linear = 42.asInstanceOf[Int with Linear]
   println(x) // assert: LinearTypes

--- a/input/src/main/scala/fix/SingleUse.scala
+++ b/input/src/main/scala/fix/SingleUse.scala
@@ -1,11 +1,11 @@
 /*
 rule = LinearTypes
-*/
+ */
 package fix
 
 /**
- * Allow a [[Box]] field to be dereferenced exactly once.
- */
+  * Allow a [[Box]] field to be dereferenced exactly once.
+  */
 trait FieldUsedOnce {
   val box: Box = Box(42)
   println(box)

--- a/input/src/main/scala/fix/Unused.scala
+++ b/input/src/main/scala/fix/Unused.scala
@@ -1,40 +1,40 @@
 /*
 rule = LinearTypes
-*/
+ */
 package fix
 
 import com.earldouglas.linearscala.Linear
 
 /**
- * Don't allow a [[Box]] field to be created but never dereferenced.
- */
+  * Don't allow a [[Box]] field to be created but never dereferenced.
+  */
 trait UnusedField {
   val box: Box = // assert: LinearTypes
     Box(42)
 }
 
 /**
- * Don't allow a [[Box]] parameter to be declared but never dereferenced.
- */
+  * Don't allow a [[Box]] parameter to be declared but never dereferenced.
+  */
 trait UnusedParameter {
   def foo(
-    x: Box,
-    y: Box // assert: LinearTypes
+      x: Box,
+      y: Box // assert: LinearTypes
   ): Int =
     x.value
 }
 
 /**
- * Don't allow a [[Box]] method to be created but never called.
- */
+  * Don't allow a [[Box]] method to be created but never called.
+  */
 trait UnusedMethod {
   def foo(): Box = // assert: LinearTypes
     Box(42)
 }
 
 /**
- * Don't allow a [[Box]] value to be created but never dereferenced.
- */
+  * Don't allow a [[Box]] value to be created but never dereferenced.
+  */
 trait UnusedValue {
   def foo(): Unit = {
     val x: Box = Box(42) // assert: LinearTypes
@@ -42,9 +42,9 @@ trait UnusedValue {
 }
 
 /**
- * Don't allow a [[Box]] binding in a for comprehension to be
- * created but never dereferenced.
- */
+  * Don't allow a [[Box]] binding in a for comprehension to be
+  * created but never dereferenced.
+  */
 trait UnusedBinding {
   for {
     x <- Some(Box(6)) // assert: LinearTypes
@@ -54,22 +54,22 @@ trait UnusedBinding {
 }
 
 /**
- * Don't allow a field with a [[Linear]] structural type to be
- * created but never dereferenced.
- */
+  * Don't allow a field with a [[Linear]] structural type to be
+  * created but never dereferenced.
+  */
 trait UnusedFieldWithStructuralType {
   val x: Int with Linear = // assert: LinearTypes
     42.asInstanceOf[Int with Linear]
 }
 
 /**
- * Don't allow a parameter with a [[Linear]] structural type to be
- * declared but never dereferenced.
- */
+  * Don't allow a parameter with a [[Linear]] structural type to be
+  * declared but never dereferenced.
+  */
 trait UnusedParameterWithStructuralType {
   def foo(
-    x: Int,
-    y: Int with Linear // assert: LinearTypes
+      x: Int,
+      y: Int with Linear // assert: LinearTypes
   ): Int =
     42
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.27")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")


### PR DESCRIPTION
This adds sbt-scalafmt and updates the `build` CI step to check whether
sources have been formatting.  This also applies formatting to all
sources so that the CI check will pass.