### PR TITLE
scalafix: 0.11.0 -> 0.11.1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.1")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")


### PR DESCRIPTION
📦 Updates 
* [ch.epfl.scala:sbt-scalafix](https://github.com/scalacenter/sbt-scalafix)
* [ch.epfl.scala:scalafix-core](https://github.com/scalacenter/scalafix)

 from `0.11.0` to `0.11.1`

📜 [GitHub Release Notes](https://github.com/scalacenter/sbt-scalafix/releases/tag/v0.11.1) - [Version Diff](https://github.com/scalacenter/sbt-scalafix/compare/v0.11.0...v0.11.1)