### PR TITLE
scalafmt-core: 3.7.17 -> 3.8.0

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,3 @@
-version = 3.7.17 // https://scalameta.org/scalafmt/docs/installation.html#sbt
+version = 3.8.0 // https://scalameta.org/scalafmt/docs/installation.html#sbt
 runner.dialect = scala213 // https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects
 maxColumn = 72 // RFC 678: https://datatracker.ietf.org/doc/html/rfc678


### PR DESCRIPTION
📦 Updates [org.scalameta:scalafmt-core](https://github.com/scalameta/scalafmt) from `3.7.17` to `3.8.0`

📜 [GitHub Release Notes](https://github.com/scalameta/scalafmt/releases/tag/v3.8.0) - [Version Diff](https://github.com/scalameta/scalafmt/compare/v3.7.17...v3.8.0)