### PR TITLE
sbt-scalafix, scalafix-core: 0.11.1 -> 0.12.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")


### PR DESCRIPTION
📦 Updates 
* [ch.epfl.scala:sbt-scalafix](https://github.com/scalacenter/sbt-scalafix)
* [ch.epfl.scala:scalafix-core](https://github.com/scalacenter/scalafix)

 from `0.11.1` to `0.12.0`

📜 [GitHub Release Notes](https://github.com/scalacenter/sbt-scalafix/releases/tag/v0.12.0) - [Version Diff](https://github.com/scalacenter/sbt-scalafix/compare/v0.11.1...v0.12.0)