### PR TITLE
sbt-scalafix, scalafix-core: 0.12.0 -> 0.12.1

### DIFF
--- a/plugin/src/main/scala/LinearScala.scala
+++ b/plugin/src/main/scala/LinearScala.scala
@@ -14,8 +14,6 @@ object LinearScala extends AutoPlugin {
     Seq(
       ScalafixPlugin.autoImport.scalafixDependencies +=
         "com.earldouglas" %% "linear-scala-scalafix" % LinearScalaBuildInfo.version,
-      ScalafixPlugin.autoImport.scalafixScalaBinaryVersion :=
-        CrossVersion.binaryScalaVersion(scalaVersion.value),
       semanticdbEnabled := true,
       semanticdbVersion := ScalafixPlugin.autoImport.scalafixSemanticdb.revision
     )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")


### PR DESCRIPTION
📦 Updates 
* [ch.epfl.scala:sbt-scalafix](https://github.com/scalacenter/sbt-scalafix)
* [ch.epfl.scala:scalafix-core](https://github.com/scalacenter/scalafix)

 from `0.12.0` to `0.12.1`

📜 [GitHub Release Notes](https://github.com/scalacenter/sbt-scalafix/releases/tag/v0.12.1) - [Version Diff](https://github.com/scalacenter/sbt-scalafix/compare/v0.12.0...v0.12.1)