### PR TITLE
sbt: 1.9.9 -> 1.10.0

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.0


### PR DESCRIPTION
📦 Updates [org.scala-sbt:sbt](https://github.com/sbt/sbt) from `1.9.9` to `1.10.0`

📜 [GitHub Release Notes](https://github.com/sbt/sbt/releases/tag/v1.10.0) - [Version Diff](https://github.com/sbt/sbt/compare/v1.9.9...v1.10.0)