### PR TITLE
sbt: 1.10.0 -> 1.10.1

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.0
+sbt.version=1.10.1


### PR DESCRIPTION
📦 Updates [org.scala-sbt:sbt](https://github.com/sbt/sbt) from `1.10.0` to `1.10.1`

📜 [GitHub Release Notes](https://github.com/sbt/sbt/releases/tag/v1.10.1) - [Version Diff](https://github.com/sbt/sbt/compare/v1.10.0...v1.10.1)