### PR TITLE
sbt-ci-release: 1.5.12 -> 1.6.1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")


### PR DESCRIPTION
📦 Updates [com.github.sbt:sbt-ci-release](https://github.com/sbt/sbt-ci-release) from `1.5.12` to `1.6.1`

📜 [GitHub Release Notes](https://github.com/sbt/sbt-ci-release/releases/tag/v1.6.1) - [Version Diff](https://github.com/sbt/sbt-ci-release/compare/v1.5.12...v1.6.1)