### PR TITLE
sbt-ci-release: 1.6.1 -> 1.7.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.13.0")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.1")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.7.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")


### PR DESCRIPTION
📦 Updates [com.github.sbt:sbt-ci-release](https://github.com/sbt/sbt-ci-release) from `1.6.1` to `1.7.0`

📜 [GitHub Release Notes](https://github.com/sbt/sbt-ci-release/releases/tag/v1.7.0) - [Version Diff](https://github.com/sbt/sbt-ci-release/compare/v1.6.1...v1.7.0)